### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2021 - 2022 Injective Foundation (https://injectivelabs.org/)
+Copyright © 2021 - 2025 Injective Foundation (https://injectivelabs.org/)
 
                                  Apache License
                            Version 2.0, January 2004


### PR DESCRIPTION
Updated the copyright year from 2022 to 2025 in the LICENSE file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated LICENSE copyright year range from 2022 to 2025 for Injective Foundation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->